### PR TITLE
Clarify initial hardware discovery docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 
 ## Current MVP
 
-- Detects known Sony USB HID identifiers for DualSense, DualSense Edge, and DualShock 4 through a mockable device scanner boundary.
+- Defines known Sony USB HID identifiers for DualSense, DualSense Edge, and DualShock 4 behind a mockable device scanner boundary. Real Windows HID scanning is planned next.
 - Falls back to a mock DualSense in the desktop app when no hardware is available.
 - Prints deterministic CLI diagnostics with `psce devices --mock`.
 - Defines core modules for remapping, lightbar color, rumble/haptics, adaptive trigger effects, and virtual controller targets.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,7 +6,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 
 ## MVP Scope
 
-- USB-first discovery for DualSense, DualSense Edge, and DualShock 4 identifiers.
+- USB-first discovery architecture for DualSense, DualSense Edge, and DualShock 4 identifiers, with the real Windows HID scanner tracked as follow-up work.
 - Desktop app that shows connected controller model, battery status when available, connection type, and current input state.
 - Mock controller mode so UI and CLI workflows can be tested without hardware.
 - CLI diagnostics for QA and issue reports.

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -31,6 +31,8 @@
 
 ## With PlayStation Controller Hardware
 
+Real USB HID scanning is not implemented in the initial skeleton. Use this section after `IHidDeviceScanner` has a Windows HID implementation.
+
 1. Connect one supported controller over USB:
    - DualSense
    - DualSense Edge


### PR DESCRIPTION
## Summary
- Clarifies that the initial skeleton defines USB HID identifiers and scanner boundaries, but does not yet implement real Windows HID scanning.
- Marks hardware QA steps as applicable after IHidDeviceScanner has a Windows implementation.
- Aligns PRD MVP wording with the current implementation state.

## Validation
- dotnet build PSControllerEmulator.sln --configuration Release
- dotnet test PSControllerEmulator.sln --configuration Release --no-build

Closes #6