### PR TITLE
Implement real Windows USB HID scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 
 ## Current MVP
 
-- Defines known Sony USB HID identifiers for DualSense, DualSense Edge, and DualShock 4 behind a mockable device scanner boundary. Real Windows HID scanning is planned next.
+- Enumerates Windows USB HID devices and detects supported Sony PlayStation controllers by VID/PID: DualSense, DualSense Edge, and DualShock 4.
 - Falls back to a mock DualSense in the desktop app when no hardware is available.
 - Prints deterministic CLI diagnostics with `psce devices --mock`.
 - Defines core modules for remapping, lightbar color, rumble/haptics, adaptive trigger effects, and virtual controller targets.
 - Runs automated tests without controller hardware.
+
+Input report parsing, battery extraction from real hardware, Bluetooth discovery, and virtual gamepad emulation are future work.
 
 ## Architecture
 
@@ -50,6 +52,7 @@ If no supported USB controller is found, the app displays a mock DualSense so th
 ## Run The CLI
 
 ```powershell
+dotnet run --project src/PSControllerEmulator.Cli -- devices
 dotnet run --project src/PSControllerEmulator.Cli -- devices --mock
 ```
 
@@ -67,7 +70,7 @@ dotnet test
 
 ## Roadmap
 
-1. Implement a real Windows HID scanner behind `IHidDeviceScanner`.
+1. Parse USB input reports and extract real battery status where available.
 2. Add Bluetooth discovery and pairing diagnostics.
 3. Integrate a user-selectable virtual gamepad backend for Xbox 360, DualShock 4, and DualSense targets.
 4. Add persisted remapping profiles and import/export.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 
 Input report parsing, battery extraction from real hardware, Bluetooth discovery, and virtual gamepad emulation are future work.
 
+USB transport is inferred conservatively from Windows HID device paths. Ambiguous HID devices and Bluetooth-looking paths are skipped rather than reported as USB.
+
 ## Architecture
 
 ```text

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -27,6 +27,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 - Windows HID APIs require careful permission and hotplug handling.
 - Battery and feature availability differ across USB, Bluetooth, firmware versions, and controller models.
 - HID enumeration may be affected by Windows permissions, exclusive device access, or third-party drivers.
+- USB transport inference is conservative: ambiguous HID paths are skipped instead of being labeled USB.
 - Virtual controller backends may require drivers, elevated setup, or user consent.
 - Adaptive trigger and haptic behavior must be implemented conservatively and tested on real hardware.
 - Hardware compatibility data needs privacy review before collection or upload.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,7 +6,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 
 ## MVP Scope
 
-- USB-first discovery architecture for DualSense, DualSense Edge, and DualShock 4 identifiers, with the real Windows HID scanner tracked as follow-up work.
+- USB-first discovery for DualSense, DualSense Edge, and DualShock 4 via read-only Windows HID enumeration.
 - Desktop app that shows connected controller model, battery status when available, connection type, and current input state.
 - Mock controller mode so UI and CLI workflows can be tested without hardware.
 - CLI diagnostics for QA and issue reports.
@@ -26,6 +26,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 
 - Windows HID APIs require careful permission and hotplug handling.
 - Battery and feature availability differ across USB, Bluetooth, firmware versions, and controller models.
+- HID enumeration may be affected by Windows permissions, exclusive device access, or third-party drivers.
 - Virtual controller backends may require drivers, elevated setup, or user consent.
 - Adaptive trigger and haptic behavior must be implemented conservatively and tested on real hardware.
 - Hardware compatibility data needs privacy review before collection or upload.
@@ -33,7 +34,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 ## Milestones
 
 1. Repository skeleton, mock discovery, WPF status app, CLI diagnostics, tests, docs, and CI.
-2. Real USB HID scanner with hotplug refresh and safe read-only status polling.
-3. Manual QA pass across DualSense, DualSense Edge, and DualShock 4 over USB.
+2. Manual QA pass across DualSense, DualSense Edge, and DualShock 4 over USB.
+3. Input report parsing and battery extraction.
 4. Remapping profile editor with persisted local settings.
 5. Virtual gamepad backend proof of concept with user-visible driver status.

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -31,7 +31,7 @@
 
 ## With PlayStation Controller Hardware
 
-USB HID discovery is read-only. Input parsing, battery extraction from real hardware, Bluetooth, and virtual emulation are future work.
+USB HID discovery is read-only. The scanner only reports devices with USB-looking Windows HID paths; ambiguous HID paths are skipped rather than labeled USB. Input parsing, battery extraction from real hardware, Bluetooth, and virtual emulation are future work.
 
 1. Connect one supported controller over USB:
    - DualSense

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -31,7 +31,7 @@
 
 ## With PlayStation Controller Hardware
 
-Real USB HID scanning is not implemented in the initial skeleton. Use this section after `IHidDeviceScanner` has a Windows HID implementation.
+USB HID discovery is read-only. Input parsing, battery extraction from real hardware, Bluetooth, and virtual emulation are future work.
 
 1. Connect one supported controller over USB:
    - DualSense
@@ -47,7 +47,8 @@ Real USB HID scanning is not implemented in the initial skeleton. Use this secti
    dotnet run --project src/PSControllerEmulator.Cli -- devices
    ```
 
-7. Record controller model, Windows version, connection type, and any incorrect status in a hardware compatibility report.
+7. Confirm one entry appears for the connected controller with connection type `USB`.
+8. Record controller model, Windows version, connection type, product/manufacturer naming, and any incorrect status in a hardware compatibility report.
 
 ## Regression Checklist
 

--- a/src/PSControllerEmulator.Devices/DeviceServiceFactory.cs
+++ b/src/PSControllerEmulator.Devices/DeviceServiceFactory.cs
@@ -10,16 +10,23 @@ public static class DeviceServiceFactory
         return CreateDefault(enableMockFallback: true);
     }
 
-    public static IControllerDiscoveryService CreateForCli(bool useMock)
+    public static IControllerDiscoveryService CreateForCli(bool useMock, IHidDeviceScanner? scanner = null)
     {
-        return useMock ? new MockControllerDiscoveryService() : CreateDefault(enableMockFallback: false);
+        return useMock ? new MockControllerDiscoveryService() : CreateDefault(enableMockFallback: false, scanner);
     }
 
-    public static IControllerDiscoveryService CreateDefault(bool enableMockFallback)
+    public static IControllerDiscoveryService CreateDefault(bool enableMockFallback, IHidDeviceScanner? scanner = null)
     {
         return new ControllerDiscoveryService(
-            new HardwareControllerDiscoveryService(new NullHidDeviceScanner()),
+            new HardwareControllerDiscoveryService(scanner ?? CreateHidDeviceScanner()),
             new MockControllerDiscoveryService(),
             enableMockFallback);
+    }
+
+    private static IHidDeviceScanner CreateHidDeviceScanner()
+    {
+        return OperatingSystem.IsWindows()
+            ? new WindowsHidDeviceScanner()
+            : new NullHidDeviceScanner();
     }
 }

--- a/src/PSControllerEmulator.Devices/Hid/HidDeviceInfo.cs
+++ b/src/PSControllerEmulator.Devices/Hid/HidDeviceInfo.cs
@@ -7,4 +7,5 @@ public sealed record HidDeviceInfo(
     ushort VendorId,
     ushort ProductId,
     string ProductName,
+    string ManufacturerName,
     ConnectionType ConnectionType);

--- a/src/PSControllerEmulator.Devices/Hid/HidTransportClassifier.cs
+++ b/src/PSControllerEmulator.Devices/Hid/HidTransportClassifier.cs
@@ -1,0 +1,17 @@
+namespace PSControllerEmulator.Devices.Hid;
+
+public static class HidTransportClassifier
+{
+    public static bool IsUsbDevicePath(string devicePath)
+    {
+        if (string.IsNullOrWhiteSpace(devicePath))
+        {
+            return false;
+        }
+
+        var normalized = devicePath.Trim().Replace('/', '\\').ToLowerInvariant();
+
+        return normalized.StartsWith(@"\\?\hid#vid_", StringComparison.Ordinal)
+            && normalized.Contains("&pid_", StringComparison.Ordinal);
+    }
+}

--- a/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
+++ b/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
@@ -124,6 +124,11 @@ public sealed class WindowsHidDeviceScanner : IHidDeviceScanner
     {
         deviceInfo = default!;
 
+        if (!HidTransportClassifier.IsUsbDevicePath(devicePath))
+        {
+            return false;
+        }
+
         using var handle = CreateFile(
             devicePath,
             MetadataOnlyAccess,

--- a/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
+++ b/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
@@ -1,0 +1,262 @@
+using Microsoft.Win32.SafeHandles;
+using PSControllerEmulator.Core.Controllers;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PSControllerEmulator.Devices.Hid;
+
+public sealed class WindowsHidDeviceScanner : IHidDeviceScanner
+{
+    private const int DigcfPresent = 0x00000002;
+    private const int DigcfDeviceinterface = 0x00000010;
+    private const uint MetadataOnlyAccess = 0;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagOverlapped = 0x40000000;
+    private static readonly IntPtr InvalidHandleValue = new(-1);
+
+    public Task<IReadOnlyList<HidDeviceInfo>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return Task.FromResult<IReadOnlyList<HidDeviceInfo>>(Array.Empty<HidDeviceInfo>());
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        HidD_GetHidGuid(out var hidGuid);
+        var deviceInfoSet = SetupDiGetClassDevs(
+            ref hidGuid,
+            null,
+            IntPtr.Zero,
+            DigcfPresent | DigcfDeviceinterface);
+
+        if (deviceInfoSet == InvalidHandleValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to enumerate HID devices.");
+        }
+
+        var devices = new List<HidDeviceInfo>();
+
+        try
+        {
+            var index = 0u;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var interfaceData = SP_DEVICE_INTERFACE_DATA.Create();
+
+                if (!SetupDiEnumDeviceInterfaces(deviceInfoSet, IntPtr.Zero, ref hidGuid, index, ref interfaceData))
+                {
+                    var error = Marshal.GetLastWin32Error();
+
+                    if (error == Win32ErrorNoMoreItems)
+                    {
+                        break;
+                    }
+
+                    throw new Win32Exception(error, "Unable to enumerate a HID device interface.");
+                }
+
+                var path = GetDevicePath(deviceInfoSet, interfaceData);
+
+                if (!string.IsNullOrWhiteSpace(path) && TryReadDeviceInfo(path, out var deviceInfo))
+                {
+                    devices.Add(deviceInfo);
+                }
+
+                index++;
+            }
+        }
+        finally
+        {
+            SetupDiDestroyDeviceInfoList(deviceInfoSet);
+        }
+
+        return Task.FromResult<IReadOnlyList<HidDeviceInfo>>(devices);
+    }
+
+    private static string GetDevicePath(IntPtr deviceInfoSet, SP_DEVICE_INTERFACE_DATA interfaceData)
+    {
+        SetupDiGetDeviceInterfaceDetail(
+            deviceInfoSet,
+            ref interfaceData,
+            IntPtr.Zero,
+            0,
+            out var requiredSize,
+            IntPtr.Zero);
+
+        if (requiredSize == 0)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to determine HID device path length.");
+        }
+
+        var detailData = Marshal.AllocHGlobal((int)requiredSize);
+
+        try
+        {
+            Marshal.WriteInt32(detailData, IntPtr.Size == 8 ? 8 : 6);
+
+            if (!SetupDiGetDeviceInterfaceDetail(
+                deviceInfoSet,
+                ref interfaceData,
+                detailData,
+                requiredSize,
+                out _,
+                IntPtr.Zero))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to read HID device path.");
+            }
+
+            return Marshal.PtrToStringUni(IntPtr.Add(detailData, 4)) ?? string.Empty;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(detailData);
+        }
+    }
+
+    private static bool TryReadDeviceInfo(string devicePath, out HidDeviceInfo deviceInfo)
+    {
+        deviceInfo = default!;
+
+        using var handle = CreateFile(
+            devicePath,
+            MetadataOnlyAccess,
+            FileShareRead | FileShareWrite,
+            IntPtr.Zero,
+            OpenExisting,
+            FileFlagOverlapped,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            return false;
+        }
+
+        var attributes = HIDD_ATTRIBUTES.Create();
+
+        if (!HidD_GetAttributes(handle, ref attributes))
+        {
+            return false;
+        }
+
+        deviceInfo = new HidDeviceInfo(
+            devicePath,
+            attributes.VendorID,
+            attributes.ProductID,
+            ReadHidString(handle, HidStringKind.Product),
+            ReadHidString(handle, HidStringKind.Manufacturer),
+            ConnectionType.Usb);
+
+        return true;
+    }
+
+    private static string ReadHidString(SafeFileHandle handle, HidStringKind kind)
+    {
+        var buffer = new StringBuilder(256);
+        var success = kind switch
+        {
+            HidStringKind.Product => HidD_GetProductString(handle, buffer, buffer.Capacity * sizeof(char)),
+            HidStringKind.Manufacturer => HidD_GetManufacturerString(handle, buffer, buffer.Capacity * sizeof(char)),
+            _ => false
+        };
+
+        return success ? buffer.ToString().TrimEnd('\0') : string.Empty;
+    }
+
+    private enum HidStringKind
+    {
+        Product,
+        Manufacturer
+    }
+
+    private const int Win32ErrorNoMoreItems = 259;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVICE_INTERFACE_DATA
+    {
+        public int cbSize;
+        public Guid InterfaceClassGuid;
+        public int Flags;
+        public IntPtr Reserved;
+
+        public static SP_DEVICE_INTERFACE_DATA Create()
+        {
+            return new SP_DEVICE_INTERFACE_DATA
+            {
+                cbSize = Marshal.SizeOf<SP_DEVICE_INTERFACE_DATA>()
+            };
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HIDD_ATTRIBUTES
+    {
+        public int Size;
+        public ushort VendorID;
+        public ushort ProductID;
+        public ushort VersionNumber;
+
+        public static HIDD_ATTRIBUTES Create()
+        {
+            return new HIDD_ATTRIBUTES
+            {
+                Size = Marshal.SizeOf<HIDD_ATTRIBUTES>()
+            };
+        }
+    }
+
+    [DllImport("hid.dll")]
+    private static extern void HidD_GetHidGuid(out Guid hidGuid);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    private static extern bool HidD_GetAttributes(SafeFileHandle hidDeviceObject, ref HIDD_ATTRIBUTES attributes);
+
+    [DllImport("hid.dll", EntryPoint = "HidD_GetProductString", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+    private static extern bool HidD_GetProductString(SafeFileHandle hidDeviceObject, StringBuilder buffer, int bufferLength);
+
+    [DllImport("hid.dll", EntryPoint = "HidD_GetManufacturerString", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+    private static extern bool HidD_GetManufacturerString(SafeFileHandle hidDeviceObject, StringBuilder buffer, int bufferLength);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr SetupDiGetClassDevs(
+        ref Guid classGuid,
+        string? enumerator,
+        IntPtr hwndParent,
+        int flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiEnumDeviceInterfaces(
+        IntPtr deviceInfoSet,
+        IntPtr deviceInfoData,
+        ref Guid interfaceClassGuid,
+        uint memberIndex,
+        ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool SetupDiGetDeviceInterfaceDetail(
+        IntPtr deviceInfoSet,
+        ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData,
+        IntPtr deviceInterfaceDetailData,
+        uint deviceInterfaceDetailDataSize,
+        out uint requiredSize,
+        IntPtr deviceInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr deviceInfoSet);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateFile(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+}

--- a/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
+++ b/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
@@ -42,6 +42,7 @@ public sealed class MockDiscoveryTests
                 PlayStationControllerDetector.SonyVendorId,
                 PlayStationControllerDetector.DualSenseProductId,
                 "Wireless Controller",
+                "Sony Interactive Entertainment",
                 ConnectionType.Usb)
         ]);
         var discovery = new HardwareControllerDiscoveryService(scanner);
@@ -54,11 +55,81 @@ public sealed class MockDiscoveryTests
         Assert.False(controller.IsMock);
     }
 
+    [Theory]
+    [InlineData(PlayStationControllerDetector.DualSenseProductId, ControllerModel.DualSense)]
+    [InlineData(PlayStationControllerDetector.DualSenseEdgeProductId, ControllerModel.DualSenseEdge)]
+    [InlineData(PlayStationControllerDetector.DualShock4ProductId, ControllerModel.DualShock4)]
+    [InlineData(PlayStationControllerDetector.DualShock4SlimProductId, ControllerModel.DualShock4)]
+    public void DetectorMapsSupportedSonyUsbProducts(int productId, ControllerModel expectedModel)
+    {
+        var device = new HidDeviceInfo(
+            "hid://controller",
+            PlayStationControllerDetector.SonyVendorId,
+            (ushort)productId,
+            string.Empty,
+            "Sony Interactive Entertainment",
+            ConnectionType.Usb);
+
+        var mapped = PlayStationControllerDetector.TryCreateController(device, out var controller);
+
+        Assert.True(mapped);
+        Assert.NotNull(controller);
+        Assert.Equal(expectedModel, controller.Model);
+        Assert.Equal(expectedModel.ToDisplayName(), controller.DisplayName);
+    }
+
+    [Fact]
+    public void DetectorIgnoresUnsupportedSonyUsbProduct()
+    {
+        var device = new HidDeviceInfo(
+            "hid://unsupported",
+            PlayStationControllerDetector.SonyVendorId,
+            0x0001,
+            "Unsupported Sony HID",
+            "Sony",
+            ConnectionType.Usb);
+
+        var mapped = PlayStationControllerDetector.TryCreateController(device, out var controller);
+
+        Assert.False(mapped);
+        Assert.Null(controller);
+    }
+
+    [Fact]
+    public async Task EmptyHardwareScanReturnsNoControllers()
+    {
+        var discovery = new HardwareControllerDiscoveryService(new FakeHidDeviceScanner([]));
+
+        var controllers = await discovery.DiscoverAsync();
+
+        Assert.Empty(controllers);
+    }
+
+    [Fact]
+    public async Task CliMockModeBypassesHardwareScanner()
+    {
+        var discovery = DeviceServiceFactory.CreateForCli(useMock: true, new ThrowingHidDeviceScanner());
+
+        var controllers = await discovery.DiscoverAsync();
+
+        var controller = Assert.Single(controllers);
+        Assert.True(controller.IsMock);
+        Assert.Equal(ControllerModel.DualSense, controller.Model);
+    }
+
     private sealed class FakeHidDeviceScanner(IReadOnlyList<HidDeviceInfo> devices) : IHidDeviceScanner
     {
         public Task<IReadOnlyList<HidDeviceInfo>> ScanAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(devices);
+        }
+    }
+
+    private sealed class ThrowingHidDeviceScanner : IHidDeviceScanner
+    {
+        public Task<IReadOnlyList<HidDeviceInfo>> ScanAsync(CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Hardware scanner should not run in mock mode.");
         }
     }
 }

--- a/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
+++ b/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
@@ -117,6 +117,23 @@ public sealed class MockDiscoveryTests
         Assert.Equal(ControllerModel.DualSense, controller.Model);
     }
 
+    [Fact]
+    public void UsbLookingHidPathIsAcceptedAsUsb()
+    {
+        var path = @"\\?\hid#vid_054c&pid_0ce6&mi_03#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}";
+
+        Assert.True(HidTransportClassifier.IsUsbDevicePath(path));
+    }
+
+    [Theory]
+    [InlineData(@"\\?\hid#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")]
+    [InlineData(@"\\?\bthenum#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000")]
+    [InlineData(@"\\?\hid#sony_controller#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")]
+    public void NonUsbOrAmbiguousHidPathIsRejected(string path)
+    {
+        Assert.False(HidTransportClassifier.IsUsbDevicePath(path));
+    }
+
     private sealed class FakeHidDeviceScanner(IReadOnlyList<HidDeviceInfo> devices) : IHidDeviceScanner
     {
         public Task<IReadOnlyList<HidDeviceInfo>> ScanAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Implements read-only Windows USB HID enumeration behind `IHidDeviceScanner` using SetupAPI/HID metadata calls.
- Wires the real scanner into default hardware discovery on Windows while preserving mock mode and mock fallback.
- Extends HID metadata with manufacturer name and adds hardware-free tests for VID/PID mapping, mock bypass, and empty scans.
- Updates README/PRD/QA docs to reflect USB scanning status and future-work boundaries.

## Validation
- `dotnet build PSControllerEmulator.sln --configuration Release`
- `dotnet test PSControllerEmulator.sln --configuration Release --no-build`
- `dotnet run --project src/PSControllerEmulator.Cli -- devices --mock`
- `dotnet run --project src/PSControllerEmulator.Cli -- devices`

## Notes
- No physical PlayStation controller was attached in this environment; real CLI discovery completed and reported no supported controllers.
- Input report parsing, battery extraction from real hardware, Bluetooth, and virtual gamepad drivers remain future work.

Closes #4
