### PR TITLE
Add Bluetooth-capable HID discovery classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 - Defines core modules for remapping, lightbar color, rumble/haptics, adaptive trigger effects, and virtual controller targets.
 - Runs automated tests without controller hardware.
 
-Input report parsing, battery extraction from real hardware, Bluetooth discovery, and virtual gamepad emulation are future work.
+Input report parsing, battery extraction from real hardware, expanded Bluetooth metadata coverage, and virtual gamepad emulation are future work.
 
 Transport is inferred conservatively from Windows HID device paths. Ambiguous HID devices are skipped rather than mislabeled.
 
@@ -73,7 +73,7 @@ dotnet test
 ## Roadmap
 
 1. Parse USB input reports and extract real battery status where available.
-2. Add Bluetooth discovery and pairing diagnostics.
+2. Expand Bluetooth discovery coverage and add pairing diagnostics.
 3. Integrate a user-selectable virtual gamepad backend for Xbox 360, DualShock 4, and DualSense targets.
 4. Add persisted remapping profiles and import/export.
 5. Expand hardware compatibility reporting with anonymized USB metadata.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 
 ## Current MVP
 
-- Enumerates Windows USB HID devices and detects supported Sony PlayStation controllers by VID/PID: DualSense, DualSense Edge, and DualShock 4.
+- Enumerates Windows HID devices and detects supported Sony PlayStation controllers by VID/PID metadata for USB, and for Bluetooth where Windows exposes usable HID path metadata.
 - Falls back to a mock DualSense in the desktop app when no hardware is available.
 - Prints deterministic CLI diagnostics with `psce devices --mock`.
 - Defines core modules for remapping, lightbar color, rumble/haptics, adaptive trigger effects, and virtual controller targets.
@@ -18,7 +18,7 @@ This project is a clean-room implementation. It does not copy DSX code, assets, 
 
 Input report parsing, battery extraction from real hardware, Bluetooth discovery, and virtual gamepad emulation are future work.
 
-USB transport is inferred conservatively from Windows HID device paths. Ambiguous HID devices and Bluetooth-looking paths are skipped rather than reported as USB.
+Transport is inferred conservatively from Windows HID device paths. Ambiguous HID devices are skipped rather than mislabeled.
 
 ## Architecture
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -18,7 +18,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 
 - Copying DSX code, assets, branding, UI, text, or proprietary behavior.
 - Shipping kernel drivers in the initial skeleton.
-- Bluetooth discovery in the first deliverable.
+- Comprehensive Bluetooth support across all Windows stack variants in the first deliverable.
 - Production-ready Xbox 360, DS4, or DualSense emulation in the first deliverable.
 - Firmware modification or unsupported controller flashing.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,7 +6,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 
 ## MVP Scope
 
-- USB-first discovery for DualSense, DualSense Edge, and DualShock 4 via read-only Windows HID enumeration.
+- USB-first discovery for DualSense, DualSense Edge, and DualShock 4 via read-only Windows HID enumeration, with Bluetooth discovery when Windows HID metadata is sufficient.
 - Desktop app that shows connected controller model, battery status when available, connection type, and current input state.
 - Mock controller mode so UI and CLI workflows can be tested without hardware.
 - CLI diagnostics for QA and issue reports.
@@ -28,6 +28,7 @@ PS Controller Emulator helps Windows 10/11 users inspect, configure, and eventua
 - Battery and feature availability differ across USB, Bluetooth, firmware versions, and controller models.
 - HID enumeration may be affected by Windows permissions, exclusive device access, or third-party drivers.
 - USB transport inference is conservative: ambiguous HID paths are skipped instead of being labeled USB.
+- Bluetooth discovery depends on Windows exposing recognizable HID metadata; some Bluetooth paths may remain unclassified.
 - Virtual controller backends may require drivers, elevated setup, or user consent.
 - Adaptive trigger and haptic behavior must be implemented conservatively and tested on real hardware.
 - Hardware compatibility data needs privacy review before collection or upload.

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -31,7 +31,7 @@
 
 ## With PlayStation Controller Hardware
 
-USB HID discovery is read-only. The scanner only reports devices with USB-looking Windows HID paths; ambiguous HID paths are skipped rather than labeled USB. Input parsing, battery extraction from real hardware, Bluetooth, and virtual emulation are future work.
+HID discovery is read-only. USB and Bluetooth transport are inferred conservatively from Windows HID paths; ambiguous paths are skipped rather than mislabeled. Input parsing, battery extraction from real hardware, and virtual emulation are future work.
 
 1. Connect one supported controller over USB:
    - DualSense
@@ -49,6 +49,21 @@ USB HID discovery is read-only. The scanner only reports devices with USB-lookin
 
 7. Confirm one entry appears for the connected controller with connection type `USB`.
 8. Record controller model, Windows version, connection type, product/manufacturer naming, and any incorrect status in a hardware compatibility report.
+
+## Bluetooth Manual Checks (Where Available)
+
+1. Pair one supported controller in Windows Bluetooth settings:
+   - DualSense
+   - DualSense Edge
+   - DualShock 4
+2. Run:
+
+   ```powershell
+   dotnet run --project src/PSControllerEmulator.Cli -- devices
+   ```
+
+3. Confirm the controller appears with connection type `Bluetooth` when path metadata is recognizable.
+4. If the device does not appear, capture the environment details and note that path metadata may be ambiguous/unclassified.
 
 ## Regression Checklist
 

--- a/src/PSControllerEmulator.Devices/Hid/HidTransportClassifier.cs
+++ b/src/PSControllerEmulator.Devices/Hid/HidTransportClassifier.cs
@@ -1,17 +1,81 @@
+using PSControllerEmulator.Core.Controllers;
+using System.Text.RegularExpressions;
+
 namespace PSControllerEmulator.Devices.Hid;
 
-public static class HidTransportClassifier
+public static partial class HidTransportClassifier
 {
-    public static bool IsUsbDevicePath(string devicePath)
+    [GeneratedRegex(@"vid[_&](?<vid>[0-9a-f]{4,8}).*pid[_&](?<pid>[0-9a-f]{4})", RegexOptions.IgnoreCase)]
+    private static partial Regex VidPidRegex();
+
+    public static ConnectionType ClassifyConnectionType(string devicePath)
     {
+        if (string.IsNullOrWhiteSpace(devicePath))
+        {
+            return ConnectionType.Unknown;
+        }
+
+        var normalized = Normalize(devicePath);
+
+        if (normalized.StartsWith(@"\\?\hid#vid_", StringComparison.Ordinal)
+            && normalized.Contains("&pid_", StringComparison.Ordinal))
+        {
+            return ConnectionType.Usb;
+        }
+
+        if ((normalized.StartsWith(@"\\?\hid#{00001124-", StringComparison.Ordinal)
+                || normalized.StartsWith(@"\\?\bthenum#{00001124-", StringComparison.Ordinal))
+            && normalized.Contains("vid&", StringComparison.Ordinal)
+            && normalized.Contains("_pid&", StringComparison.Ordinal))
+        {
+            return ConnectionType.Bluetooth;
+        }
+
+        return ConnectionType.Unknown;
+    }
+
+    public static bool TryExtractVendorProductId(string devicePath, out ushort vendorId, out ushort productId)
+    {
+        vendorId = 0;
+        productId = 0;
+
         if (string.IsNullOrWhiteSpace(devicePath))
         {
             return false;
         }
 
-        var normalized = devicePath.Trim().Replace('/', '\\').ToLowerInvariant();
+        var normalized = Normalize(devicePath);
+        var match = VidPidRegex().Match(normalized);
 
-        return normalized.StartsWith(@"\\?\hid#vid_", StringComparison.Ordinal)
-            && normalized.Contains("&pid_", StringComparison.Ordinal);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var vendorText = match.Groups["vid"].Value;
+        var productText = match.Groups["pid"].Value;
+
+        if (vendorText.Length > 4)
+        {
+            vendorText = vendorText[^4..];
+        }
+
+        if (!ushort.TryParse(vendorText, System.Globalization.NumberStyles.HexNumber, null, out vendorId))
+        {
+            return false;
+        }
+
+        if (!ushort.TryParse(productText, System.Globalization.NumberStyles.HexNumber, null, out productId))
+        {
+            vendorId = 0;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string Normalize(string devicePath)
+    {
+        return devicePath.Trim().Replace('/', '\\').ToLowerInvariant();
     }
 }

--- a/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
+++ b/src/PSControllerEmulator.Devices/Hid/WindowsHidDeviceScanner.cs
@@ -124,10 +124,14 @@ public sealed class WindowsHidDeviceScanner : IHidDeviceScanner
     {
         deviceInfo = default!;
 
-        if (!HidTransportClassifier.IsUsbDevicePath(devicePath))
+        var connectionType = HidTransportClassifier.ClassifyConnectionType(devicePath);
+
+        if (connectionType == ConnectionType.Unknown)
         {
             return false;
         }
+
+        var hasPathIds = HidTransportClassifier.TryExtractVendorProductId(devicePath, out var pathVendorId, out var pathProductId);
 
         using var handle = CreateFile(
             devicePath,
@@ -140,23 +144,39 @@ public sealed class WindowsHidDeviceScanner : IHidDeviceScanner
 
         if (handle.IsInvalid)
         {
-            return false;
+            if (!hasPathIds)
+            {
+                return false;
+            }
+
+            deviceInfo = new HidDeviceInfo(
+                devicePath,
+                pathVendorId,
+                pathProductId,
+                string.Empty,
+                string.Empty,
+                connectionType);
+
+            return true;
         }
 
         var attributes = HIDD_ATTRIBUTES.Create();
+        var hasAttributes = HidD_GetAttributes(handle, ref attributes);
+        var vendorId = hasAttributes ? attributes.VendorID : pathVendorId;
+        var productId = hasAttributes ? attributes.ProductID : pathProductId;
 
-        if (!HidD_GetAttributes(handle, ref attributes))
+        if (vendorId == 0 || productId == 0)
         {
             return false;
         }
 
         deviceInfo = new HidDeviceInfo(
             devicePath,
-            attributes.VendorID,
-            attributes.ProductID,
+            vendorId,
+            productId,
             ReadHidString(handle, HidStringKind.Product),
             ReadHidString(handle, HidStringKind.Manufacturer),
-            ConnectionType.Usb);
+            connectionType);
 
         return true;
     }

--- a/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
+++ b/tests/PSControllerEmulator.Tests/MockDiscoveryTests.cs
@@ -122,16 +122,47 @@ public sealed class MockDiscoveryTests
     {
         var path = @"\\?\hid#vid_054c&pid_0ce6&mi_03#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}";
 
-        Assert.True(HidTransportClassifier.IsUsbDevicePath(path));
+        Assert.Equal(ConnectionType.Usb, HidTransportClassifier.ClassifyConnectionType(path));
+    }
+
+    [Fact]
+    public void BluetoothLookingHidPathIsClassifiedAsBluetooth()
+    {
+        var path = @"\\?\hid#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}";
+
+        Assert.Equal(ConnectionType.Bluetooth, HidTransportClassifier.ClassifyConnectionType(path));
+    }
+
+    [Fact]
+    public void UsbPathVendorProductIdIsExtracted()
+    {
+        var path = @"\\?\hid#vid_054c&pid_09cc&mi_03#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}";
+
+        var parsed = HidTransportClassifier.TryExtractVendorProductId(path, out var vendorId, out var productId);
+
+        Assert.True(parsed);
+        Assert.Equal(PlayStationControllerDetector.SonyVendorId, vendorId);
+        Assert.Equal(PlayStationControllerDetector.DualShock4SlimProductId, productId);
+    }
+
+    [Fact]
+    public void BluetoothPathVendorProductIdIsExtracted()
+    {
+        var path = @"\\?\bthenum#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0df2#8&2f2c7b6&0&0000";
+
+        var parsed = HidTransportClassifier.TryExtractVendorProductId(path, out var vendorId, out var productId);
+
+        Assert.True(parsed);
+        Assert.Equal(PlayStationControllerDetector.SonyVendorId, vendorId);
+        Assert.Equal(PlayStationControllerDetector.DualSenseEdgeProductId, productId);
     }
 
     [Theory]
-    [InlineData(@"\\?\hid#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")]
-    [InlineData(@"\\?\bthenum#{00001124-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000")]
     [InlineData(@"\\?\hid#sony_controller#8&2f2c7b6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")]
-    public void NonUsbOrAmbiguousHidPathIsRejected(string path)
+    [InlineData(@"\\?\hid#{11111111-0000-1000-8000-00805f9b34fb}_vid&0002054c_pid&0ce6#8&2f2c7b6&0&0000")]
+    public void AmbiguousHidPathIsRejected(string path)
     {
-        Assert.False(HidTransportClassifier.IsUsbDevicePath(path));
+        Assert.Equal(ConnectionType.Unknown, HidTransportClassifier.ClassifyConnectionType(path));
     }
 
     private sealed class FakeHidDeviceScanner(IReadOnlyList<HidDeviceInfo> devices) : IHidDeviceScanner


### PR DESCRIPTION
## Summary
- Adds conservative HID transport classification for USB and Bluetooth paths.
- Detects Bluetooth controllers where Windows exposes sufficient HID metadata.
- Keeps ambiguous paths out of discovery to avoid mislabeled USB devices.
- Falls back to path-based VID/PID metadata when direct HID attributes are unavailable.
- Updates docs to clarify Bluetooth metadata limitations.

## Validation
- `dotnet restore PSControllerEmulator.sln`
- `dotnet build PSControllerEmulator.sln --configuration Release`
- `dotnet test PSControllerEmulator.sln --configuration Release --no-build`
- `dotnet run --project src/PSControllerEmulator.Cli -- devices --mock`
- `dotnet run --project src/PSControllerEmulator.Cli -- devices`
- WPF app smoke launch

## Notes
- Real local run now detected a Bluetooth DualSense with connection type `Bluetooth`.

Closes #19
